### PR TITLE
added benchmarks for Go

### DIFF
--- a/Part 2/go_solution/exchange_test.go
+++ b/Part 2/go_solution/exchange_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"gotest.tools/assert"
@@ -66,4 +68,17 @@ func TestPriceFromFirstOrderSelected(t *testing.T) {
 	assert.Equal(t, len(trades), 1)
 
 	assert.Equal(t, trades[0].Price, Price(10))
+}
+
+func BenchmarkExchange(b *testing.B) {
+	exchange := NewExchange()
+	for i := 0; i < b.N; i++ {
+		qty := int64(rand.Intn(10000) - 5000)
+		px := float32(rand.Intn(100) + 1)
+		inst := fmt.Sprintf("I%v", rand.Intn(10))
+		_, err := exchange.Execute(makeOrder("A", inst, qty, px))
+		if err != nil {
+			b.Error(err)
+		}
+	}
 }

--- a/Part 2/go_solution/order_test.go
+++ b/Part 2/go_solution/order_test.go
@@ -65,6 +65,13 @@ func TestOrderFill(t *testing.T) {
 	assert.Equal(t, o.gen, uint64(23))
 }
 
+func BenchmarkScanOrder(b *testing.B) {
+	row := []string{"A", "COWBEL", "1000", "2"}
+	for n := 0; n < b.N; n++ {
+		_, _ = ScanOrder(row)
+	}
+}
+
 func scanOrder(party, inst string, qty int64, px uint16) (*Order, error) {
 	sqty := fmt.Sprintf("%d", qty)
 	dollars, cents := px/100, px%100

--- a/Part 2/go_solution/orderbook_test.go
+++ b/Part 2/go_solution/orderbook_test.go
@@ -67,6 +67,35 @@ func TestFirstPriceEnteredSelected(t *testing.T) {
 	assert.Equal(t, trades[1].Quantity, Quantity(50))
 }
 
+func BenchmarkOrderBookInsert(b *testing.B) {
+	book := NewOrderBook("")
+	orders := make([]Order, b.N)
+	for i := 0; i < b.N; i++ {
+		orders[i] = makeOrder("A", "EURUSD", 100, 1)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		book.Insert(orders[i])
+	}
+}
+
+func BenchmarkOrderBookMatch(b *testing.B) {
+	book := NewOrderBook("")
+	for i := 0; i < b.N; i++ {
+		book.Insert(makeOrder("A", "EURUSD", 100, 1))
+		book.Insert(makeOrder("B", "EURUSD", -100, 1))
+	}
+	b.ResetTimer()
+	trades, err := book.Match()
+	b.StopTimer()
+	if err != nil {
+		b.Error(err)
+	}
+	if len(trades) < b.N {
+		b.Errorf("trades: expected %v, got %v", b.N, len(trades))
+	}
+}
+
 func makeOrder(party, inst string, qty int64, px float32) Order {
 	buy := true
 	if qty < 0 {


### PR DESCRIPTION
I haven't done anything with the benchmarking feature, but it's pretty neat. Here you can see it runs a set of benchmark, each one for ~1 second, then shows the runtime and memory allocations. It also writes a file which the pprof tool can inspect and visualise (see below). Writing benchmark functions is really easy; now I've given it a go, I reckon I'll use it more often.

```
% go test -bench=. -benchmem -benchtime 1s -cpuprofile profile.out
goos: darwin
goarch: amd64
pkg: github.com/mrc/geh-exchange-go
BenchmarkExchange-8              2000000               888 ns/op             170 B/op          3 allocs/op
BenchmarkScanOrder-8            20000000                67.6 ns/op            64 B/op          1 allocs/op
BenchmarkOrderBookInsert-8      10000000               133 ns/op             106 B/op          1 allocs/op
BenchmarkOrderBookMatch-8        1000000              1310 ns/op             393 B/op          0 allocs/op
PASS
ok      github.com/mrc/geh-exchange-go  8.552s
```

inspect with pprof:
```
% go tool pprof -top go_solution/profile.out|head -30
Type: cpu
Time: Jun 16, 2019 at 7:36pm (PDT)
Duration: 8.44s, Total samples = 10.74s (127.19%)
Showing nodes accounting for 9.93s, 92.46% of 10.74s total
Dropped 97 nodes (cum <= 0.05s)
      flat  flat%   sum%        cum   cum%
     1.24s 11.55% 11.55%      2.45s 22.81%  runtime.scanobject
     0.89s  8.29% 19.83%      0.89s  8.29%  runtime.pthread_cond_signal
     0.80s  7.45% 27.28%      0.82s  7.64%  runtime.bulkBarrierPreWrite
     0.72s  6.70% 33.99%      0.72s  6.70%  runtime.usleep
     0.70s  6.52% 40.50%      0.70s  6.52%  runtime.memclrNoHeapPointers
     0.53s  4.93% 45.44%      0.53s  4.93%  runtime.memmove
     0.49s  4.56% 50.00%         2s 18.62%  github.com/mrc/geh-exchange-go.(*OrderBook).Insert
     0.41s  3.82% 53.82%      0.41s  3.82%  github.com/mrc/geh-exchange-go.SellQueue.Less
     0.40s  3.72% 57.54%      1.20s 11.17%  container/heap.down
     0.40s  3.72% 61.27%      0.40s  3.72%  github.com/mrc/geh-exchange-go.BuyQueue.Less
     0.33s  3.07% 64.34%      0.61s  5.68%  runtime.findObject
     0.32s  2.98% 67.32%      0.32s  2.98%  runtime.nanotime
     0.29s  2.70% 70.02%      0.29s  2.70%  runtime.pthread_cond_wait
     0.25s  2.33% 72.35%      0.29s  2.70%  runtime.spanOf
     0.19s  1.77% 74.12%      0.19s  1.77%  runtime.pthread_cond_timedwait_relative_np
     0.15s  1.40% 75.51%      0.28s  2.61%  container/heap.up
     0.15s  1.40% 76.91%      0.16s  1.49%  runtime.heapBitsSetType
     0.14s  1.30% 78.21%      0.56s  5.21%  github.com/mrc/geh-exchange-go.(*OrderQueue).Push
     0.13s  1.21% 79.42%      0.13s  1.21%  runtime.markBits.isMarked
     0.12s  1.12% 80.54%      0.13s  1.21%  github.com/mrc/geh-exchange-go.OrderQueue.Swap
     0.11s  1.02% 81.56%      0.11s  1.02%  runtime.pageIndexOf
     0.10s  0.93% 82.50%      0.10s  0.93%  runtime.(*mspan).init
     0.09s  0.84% 83.33%      0.09s  0.84%  runtime.getempty
     0.09s  0.84% 84.17%      1.32s 12.29%  runtime.mallocgc
```