### PR TITLE
Update Go ports with readme files and exe name changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin
 obj
 target/
 .ionide
+trades.txt

--- a/Part 1/go_solution/README.md
+++ b/Part 1/go_solution/README.md
@@ -1,0 +1,14 @@
+## Go solution (Part 1)
+
+Trying to match the C++ solution in style, buy and sell queues are Go
+arrays, sorted after each insert by price then time priority.
+
+## Build tools
+
+Install [go](https://golang.org)
+
+## Building and running the Go solution
+
+```
+% go build && gzip -dc ../../orders-100K.txt.gz | time ./Exchange > trades.txt
+```

--- a/Part 1/go_solution/go.mod
+++ b/Part 1/go_solution/go.mod
@@ -1,6 +1,6 @@
-module github.com/mrc/geh-exchange-go
+module github.com/mrc/Exchange
 
-go 1.12
+go 1.13
 
 require (
 	github.com/google/go-cmp v0.3.0 // indirect

--- a/Part 1/go_solution/runner
+++ b/Part 1/go_solution/runner
@@ -1,2 +1,2 @@
 #!/bin/sh
-./geh-exchange-go
+./Exchange

--- a/Part 2/go_solution/README.md
+++ b/Part 2/go_solution/README.md
@@ -1,0 +1,13 @@
+## Go solution (Part 2)
+
+Use a priority queue for buy and sell queues, to avoid sorting.
+
+## Build tools
+
+Install [go](https://golang.org)
+
+## Building and running the Go solution
+
+```
+% go build && gzip -dc ../../orders-100K.txt.gz | time ./Exchange > trades.txt
+```

--- a/Part 2/go_solution/go.mod
+++ b/Part 2/go_solution/go.mod
@@ -1,6 +1,6 @@
-module github.com/mrc/geh-exchange-go
+module github.com/mrc/Exchange
 
-go 1.11
+go 1.13
 
 require (
 	github.com/google/go-cmp v0.3.0 // indirect

--- a/Part 2/go_solution/orderqueue_test.go
+++ b/Part 2/go_solution/orderqueue_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"container/heap"
+	"math/rand"
+	"testing"
+)
+
+// benchOrder is package local to defeat optimizations
+var benchOrder *Order //nolint:gochecknoglobals
+
+func BenchmarkQueuePush(b *testing.B) {
+	q := BuyQueue{make(OrderQueue, 0, 0)}
+	heap.Init(&q)
+	o := Order{Price: Price(1.0)}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		o.gen++
+		o.Price = Price(rand.Float32())
+		heap.Push(&q, &o)
+	}
+}
+
+func BenchmarkQueuePop(b *testing.B) {
+	q := BuyQueue{make(OrderQueue, 0, 0)}
+	heap.Init(&q)
+	o := Order{Price: Price(1.0)}
+	for i := 0; i < b.N; i++ {
+		o.gen++
+		o.Price = Price(rand.Float32())
+		heap.Push(&q, &o)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchOrder = heap.Pop(&q).(*Order)
+	}
+}
+
+func BenchmarkQueuePeek(b *testing.B) {
+	q := BuyQueue{make(OrderQueue, 0, 0)}
+	heap.Init(&q)
+	o := Order{Price: Price(1.0)}
+	for i := 0; i < 100; i++ {
+		o.gen++
+		o.Price = Price(rand.Float32())
+		heap.Push(&q, &o)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchOrder = q.Peek()
+	}
+}

--- a/Part 2/go_solution/runner
+++ b/Part 2/go_solution/runner
@@ -1,2 +1,2 @@
 #!/bin/sh
-./geh-exchange-go
+./Exchange

--- a/azure-pipelines-part-1-go.yml
+++ b/azure-pipelines-part-1-go.yml
@@ -20,7 +20,7 @@ steps:
 
 - task: CopyFiles@2
   inputs:
-    contents: 'Part 1/go_solution/geh-exchange-go'
+    contents: 'Part 1/go_solution/Exchange'
     targetFolder: $(Build.ArtifactStagingDirectory)
     flattenFolders: true
 - task: CopyFiles@2

--- a/azure-pipelines-part-2-go.yml
+++ b/azure-pipelines-part-2-go.yml
@@ -16,7 +16,7 @@ steps:
   displayName: 'go build'
 - task: CopyFiles@2
   inputs:
-    contents: 'Part 2/go_solution/geh-exchange-go'
+    contents: 'Part 2/go_solution/Exchange'
     targetFolder: $(Build.ArtifactStagingDirectory)
     flattenFolders: true
 - task: CopyFiles@2


### PR DESCRIPTION
Build artifacts and sample output should be ignored by git.  Changed
the Go ports to build binaries called "Exchange" to match the C++
version.

Added readme files to the Go ports to show how to build and run them.

Updated to use Go 1.13.