### PR TITLE
Go: reduce copying of orders

### DIFF
--- a/Part 2/go_solution/exchange.go
+++ b/Part 2/go_solution/exchange.go
@@ -24,7 +24,7 @@ func (ex *Exchange) Book(ins string) *OrderBook {
 	return ob
 }
 
-func (ex *Exchange) Execute(o Order) ([]Trade, error) {
+func (ex *Exchange) Execute(o *Order) ([]Trade, error) {
 	ob := ex.Book(o.Instrument)
 	ob.Insert(o)
 	return ob.Match()
@@ -53,7 +53,7 @@ func main() {
 		if verbose {
 			fmt.Println(o)
 		}
-		trades, err := exchange.Execute(*o)
+		trades, err := exchange.Execute(o)
 		if err != nil {
 			panic(err)
 		}

--- a/Part 2/go_solution/orderbook.go
+++ b/Part 2/go_solution/orderbook.go
@@ -61,13 +61,13 @@ func (ob *OrderBook) String() string {
 	return sb.String()
 }
 
-func (ob *OrderBook) Insert(o Order) {
+func (ob *OrderBook) Insert(o *Order) {
 	o.gen = ob.nextgen
 	ob.nextgen++
 	if o.IsBuy {
-		heap.Push(&ob.Buys, &o)
+		heap.Push(&ob.Buys, o)
 	} else {
-		heap.Push(&ob.Sells, &o)
+		heap.Push(&ob.Sells, o)
 	}
 }
 

--- a/Part 2/go_solution/orderbook_test.go
+++ b/Part 2/go_solution/orderbook_test.go
@@ -16,7 +16,7 @@ func TestOrderBookOrdering(t *testing.T) {
 		for i := 0; i < int(n); i++ {
 			px := Price(rand.Intn(100))
 			buy := rand.Uint32()%2 == 0
-			book.Insert(Order{
+			book.Insert(&Order{
 				Price: px,
 				IsBuy: buy,
 			})
@@ -69,7 +69,7 @@ func TestFirstPriceEnteredSelected(t *testing.T) {
 
 func BenchmarkOrderBookInsert(b *testing.B) {
 	book := NewOrderBook("")
-	orders := make([]Order, b.N)
+	orders := make([]*Order, b.N)
 	for i := 0; i < b.N; i++ {
 		orders[i] = makeOrder("A", "EURUSD", 100, 1)
 	}
@@ -96,11 +96,11 @@ func BenchmarkOrderBookMatch(b *testing.B) {
 	}
 }
 
-func makeOrder(party, inst string, qty int64, px float32) Order {
+func makeOrder(party, inst string, qty int64, px float32) *Order {
 	buy := true
 	if qty < 0 {
 		buy = false
 		qty = -qty
 	}
-	return Order{party, inst, Quantity(qty), Quantity(qty), Price(px), buy, 0}
+	return &Order{party, inst, Quantity(qty), Quantity(qty), Price(px), buy, 0}
 }


### PR DESCRIPTION
Performance improvement about 11%.

This version:

% go build && for i in $(seq 5) ; gzip -dc ../../orders-10M.txt.gz | time ./Exchange >/dev/null
./Exchange > /dev/null  9.92s user 0.63s system 148% cpu 7.084 total
./Exchange > /dev/null  10.46s user 0.62s system 153% cpu 7.224 total
./Exchange > /dev/null  9.72s user 0.65s system 146% cpu 7.076 total
./Exchange > /dev/null  9.86s user 0.64s system 151% cpu 6.948 total
./Exchange > /dev/null  9.86s user 0.65s system 151% cpu 6.958 total

Previous version:

% go build && for i in $(seq 5) ; gzip -dc ../../orders-10M.txt.gz | time ./Exchange >/dev/null
./Exchange > /dev/null  13.42s user 0.67s system 176% cpu 7.966 total
./Exchange > /dev/null  14.31s user 0.71s system 188% cpu 7.985 total
./Exchange > /dev/null  14.79s user 0.74s system 192% cpu 8.087 total
./Exchange > /dev/null  14.39s user 0.70s system 190% cpu 7.905 total
./Exchange > /dev/null  13.86s user 0.69s system 183% cpu 7.946 total