### PR TITLE
Go: 23% speedup

### DIFF
--- a/Part 2/go_solution/.golangci.yml
+++ b/Part 2/go_solution/.golangci.yml
@@ -1,0 +1,4 @@
+issues:
+  exclude:
+    # exclude range scope lint for test cases
+    - Using the variable on range scope `tc` in function literal

--- a/Part 2/go_solution/exchange.go
+++ b/Part 2/go_solution/exchange.go
@@ -1,12 +1,5 @@
 package main
 
-import (
-	"encoding/csv"
-	"fmt"
-	"io"
-	"os"
-)
-
 type Exchange struct {
 	book map[string]*OrderBook
 }
@@ -28,42 +21,4 @@ func (ex *Exchange) Execute(o *Order) ([]Trade, error) {
 	ob := ex.Book(o.Instrument)
 	ob.Insert(o)
 	return ob.Match()
-}
-
-func main() {
-	verbose := false
-	exchange := NewExchange()
-	reader := csv.NewReader(os.Stdin)
-	reader.FieldsPerRecord = 4
-	reader.Comma = ':'
-	reader.ReuseRecord = true
-	for {
-		rec, err := reader.Read()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			panic(err)
-		}
-		o, err := ScanOrder(rec)
-		if err != nil {
-			panic(err)
-		}
-
-		if verbose {
-			fmt.Println(o)
-		}
-		trades, err := exchange.Execute(o)
-		if err != nil {
-			panic(err)
-		}
-		if len(trades) > 0 {
-			for i := range trades {
-				fmt.Println(trades[i])
-			}
-		}
-		if verbose {
-			fmt.Println(exchange.book[o.Instrument])
-		}
-	}
 }

--- a/Part 2/go_solution/main.go
+++ b/Part 2/go_solution/main.go
@@ -1,30 +1,21 @@
 package main
 
 import (
-	"encoding/csv"
 	"fmt"
-	"io"
 	"os"
 )
 
 func main() {
 	verbose := false
 	exchange := NewExchange()
-	reader := csv.NewReader(os.Stdin)
-	reader.FieldsPerRecord = 4
-	reader.Comma = ':'
-	reader.ReuseRecord = true
+	reader := NewOrderReader(os.Stdin)
 	for {
-		rec, err := reader.Read()
-		if err == io.EOF {
+		o, err := reader.Read()
+		if err != nil {
+			panic(err)
+		}
+		if o == nil {
 			break
-		}
-		if err != nil {
-			panic(err)
-		}
-		o, err := ScanOrder(rec)
-		if err != nil {
-			panic(err)
 		}
 
 		if verbose {

--- a/Part 2/go_solution/main.go
+++ b/Part 2/go_solution/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	verbose := false
+	exchange := NewExchange()
+	reader := csv.NewReader(os.Stdin)
+	reader.FieldsPerRecord = 4
+	reader.Comma = ':'
+	reader.ReuseRecord = true
+	for {
+		rec, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+		o, err := ScanOrder(rec)
+		if err != nil {
+			panic(err)
+		}
+
+		if verbose {
+			fmt.Println(o)
+		}
+		trades, err := exchange.Execute(o)
+		if err != nil {
+			panic(err)
+		}
+		if len(trades) > 0 {
+			for i := range trades {
+				fmt.Println(trades[i])
+			}
+		}
+		if verbose {
+			fmt.Println(exchange.book[o.Instrument])
+		}
+	}
+}

--- a/Part 2/go_solution/order.go
+++ b/Part 2/go_solution/order.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strconv"
-
-	"github.com/pkg/errors"
 )
 
 // Gary would use a fixed point type for prices in a real implementation
@@ -19,40 +16,6 @@ type Order struct {
 	Price       Price
 	IsBuy       bool
 	gen         uint64
-}
-
-func ScanOrder(r []string) (*Order, error) {
-	type Token int
-	const (
-		participantField Token = iota
-		instrumentField
-		quantityField
-		priceField
-		requiredFields
-	)
-	qty, err := strconv.Atoi(r[quantityField])
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing quantity")
-	}
-	px, err := strconv.ParseFloat(r[priceField], 64)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing price")
-	}
-
-	buy := qty > 0
-	if !buy {
-		qty = -qty
-	}
-
-	return &Order{
-		IsBuy:       buy,
-		Participant: r[participantField],
-		Instrument:  r[instrumentField],
-		Quantity:    Quantity(qty),
-		Remaining:   Quantity(qty),
-		Price:       Price(px),
-	}, nil
-
 }
 
 func (o *Order) Fill(qty Quantity) error {

--- a/Part 2/go_solution/order_reader.go
+++ b/Part 2/go_solution/order_reader.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/csv"
+	"io"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+type OrderReader struct {
+	reader *csv.Reader
+}
+
+func NewOrderReader(in io.Reader) *OrderReader {
+	r := csv.NewReader(in)
+	r.FieldsPerRecord = 4
+	r.Comma = ':'
+	r.ReuseRecord = true
+
+	return &OrderReader{reader: r}
+}
+
+func (s *OrderReader) Read() (*Order, error) {
+	rec, err := s.reader.Read()
+	if err == io.EOF {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	o, err := buildOrder(rec)
+	if err != nil {
+		return nil, err
+	}
+	return o, nil
+}
+
+func buildOrder(r []string) (*Order, error) {
+	type Token int
+	const (
+		participantField Token = iota
+		instrumentField
+		quantityField
+		priceField
+		requiredFields
+	)
+	qty, err := strconv.Atoi(r[quantityField])
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing quantity")
+	}
+	px, err := strconv.ParseFloat(r[priceField], 64)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing price")
+	}
+
+	buy := qty > 0
+	if !buy {
+		qty = -qty
+	}
+
+	return &Order{
+		IsBuy:       buy,
+		Participant: r[participantField],
+		Instrument:  r[instrumentField],
+		Quantity:    Quantity(qty),
+		Remaining:   Quantity(qty),
+		Price:       Price(px),
+	}, nil
+
+}

--- a/Part 2/go_solution/order_reader_test.go
+++ b/Part 2/go_solution/order_reader_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func BenchmarkBuildOrder(b *testing.B) {
+	row := []string{"A", "COWBEL", "1000", "2"}
+	for n := 0; n < b.N; n++ {
+		_, _ = buildOrder(row)
+	}
+}
+
+func TestReadOrder(t *testing.T) {
+	var tests = []struct {
+		in         string
+		party      string
+		instrument string
+		qty        Quantity
+		price      Price
+		isBuy      bool
+	}{
+		{"A:COWBEL:1000:2", "A", "COWBEL", 1000, 2, true},
+		{"A:COWBEL:-1000:2", "A", "COWBEL", 1000, 2, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			sr := strings.NewReader(tc.in)
+			reader := NewOrderReader(sr)
+			o, err := reader.Read()
+			assert.NilError(t, err)
+			assert.Assert(t, o != nil)
+			assert.Equal(t, o.Participant, tc.party)
+			assert.Equal(t, o.Instrument, tc.instrument)
+			assert.Equal(t, o.Quantity, tc.qty)
+			assert.Equal(t, o.Remaining, tc.qty)
+			assert.Equal(t, o.Price, tc.price)
+			assert.Equal(t, o.IsBuy, tc.isBuy)
+		})
+	}
+}
+
+// endless is an endlessly looping implementation of io.Reader
+type endless struct {
+	s []byte
+	c int
+}
+
+func (e *endless) Read(b []byte) (n int, err error) {
+	sl := len(e.s)
+	bl := len(b)
+	bc := 0
+	for {
+		n := copy(b[bc:], e.s[e.c:])
+		bc += n
+		e.c += n
+		if bc == bl {
+			break
+		}
+		if e.c == sl {
+			e.c = 0
+		}
+	}
+
+	return bl, nil
+}
+
+var _ io.Reader = &endless{}
+
+func BenchmarkReadOrder(b *testing.B) {
+	sr := &endless{s: []byte("A:COWBELL:1000:2\n")}
+	reader := NewOrderReader(sr)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = reader.Read()
+	}
+}

--- a/Part 2/go_solution/order_reader_test.go
+++ b/Part 2/go_solution/order_reader_test.go
@@ -24,8 +24,8 @@ func TestReadOrder(t *testing.T) {
 		price      Price
 		isBuy      bool
 	}{
-		{"A:COWBEL:1000:2", "A", "COWBEL", 1000, 2, true},
-		{"A:COWBEL:-1000:2", "A", "COWBEL", 1000, 2, false},
+		{"A:COWBEL:1000:2\n", "A", "COWBEL", 1000, 2, true},
+		{"A:COWBEL:-1000:2\n", "A", "COWBEL", 1000, 2, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.in, func(t *testing.T) {
@@ -69,13 +69,17 @@ func (e *endless) Read(b []byte) (n int, err error) {
 	return bl, nil
 }
 
+// ensure endless implements io.Reader
 var _ io.Reader = &endless{}
 
 func BenchmarkReadOrder(b *testing.B) {
-	sr := &endless{s: []byte("A:COWBELL:1000:2\n")}
+	sr := &endless{s: []byte("A:COWBELL:1000:2\nB:COWBELL:-1000:1\n")}
 	reader := NewOrderReader(sr)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, _ = reader.Read()
+		_, err := reader.Read()
+		if err != nil {
+			b.Error(err)
+		}
 	}
 }

--- a/Part 2/go_solution/order_test.go
+++ b/Part 2/go_solution/order_test.go
@@ -1,39 +1,10 @@
 package main
 
 import (
-	"fmt"
-	"math"
 	"testing"
-	"testing/quick"
 
 	"gotest.tools/assert"
 )
-
-func TestValidOrder(t *testing.T) {
-	f := func(party, inst string, qty int64, px uint16) bool {
-		o, err := scanOrder(party, inst, qty, px)
-		assert.NilError(t, err)
-
-		buy := true
-		if qty < 0 {
-			buy = false
-			qty = -qty
-		}
-
-		expectedPrice := math.Abs(float64(px) / 100)
-		pxDiff := math.Abs(float64(o.Price) - expectedPrice)
-		assert.Equal(t, o.Participant, party)
-		assert.Equal(t, o.Instrument, inst)
-		assert.Equal(t, o.Quantity, Quantity(qty))
-		assert.Equal(t, o.Remaining, Quantity(qty))
-		assert.Equal(t, o.IsBuy, buy)
-		assert.Assert(t, pxDiff < 0.009)
-		return true
-	}
-	if err := quick.Check(f, nil); err != nil {
-		t.Error(err)
-	}
-}
 
 func TestOrderFill(t *testing.T) {
 	o := &Order{
@@ -63,22 +34,4 @@ func TestOrderFill(t *testing.T) {
 	assert.Equal(t, o.Price, Price(1))
 	assert.Equal(t, o.IsBuy, true)
 	assert.Equal(t, o.gen, uint64(23))
-}
-
-func BenchmarkScanOrder(b *testing.B) {
-	row := []string{"A", "COWBEL", "1000", "2"}
-	for n := 0; n < b.N; n++ {
-		_, _ = ScanOrder(row)
-	}
-}
-
-func scanOrder(party, inst string, qty int64, px uint16) (*Order, error) {
-	sqty := fmt.Sprintf("%d", qty)
-	dollars, cents := px/100, px%100
-	spx := fmt.Sprintf("%d.%02d", dollars, cents)
-	o, err := ScanOrder([]string{party, inst, sqty, spx})
-	if err != nil {
-		return nil, err
-	}
-	return o, nil
 }


### PR DESCRIPTION
PR contains 2 refactoring commits and a specialised CSV reader.

Avoiding the guard rails and error handling of csv.reader gives a further speedup of 23% at the expense of 29% sanity.

This version:

```
% go build && for i in $(seq 5) ; gzip -dc ../../orders-10M.txt.gz | time ./Exchange >/dev/null
./Exchange > /dev/null  9.33s user 0.63s system 159% cpu 6.231 total
./Exchange > /dev/null  9.18s user 0.63s system 160% cpu 6.115 total
./Exchange > /dev/null  9.16s user 0.61s system 160% cpu 6.084 total
./Exchange > /dev/null  9.30s user 0.59s system 161% cpu 6.144 total
./Exchange > /dev/null  9.15s user 0.61s system 159% cpu 6.138 total
```

Previous version:

```
% go build && for i in $(seq 5) ; gzip -dc ../../orders-10M.txt.gz | time ./Exchange >/dev/null
./Exchange > /dev/null  13.42s user 0.67s system 176% cpu 7.966 total
./Exchange > /dev/null  14.31s user 0.71s system 188% cpu 7.985 total
./Exchange > /dev/null  14.79s user 0.74s system 192% cpu 8.087 total
./Exchange > /dev/null  14.39s user 0.70s system 190% cpu 7.905 total
./Exchange > /dev/null  13.86s user 0.69s system 183% cpu 7.946 total
```