### PR TITLE
Add Python implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ obj
 target/
 .ionide
 trades.txt
+*.pyc
+__pycache__/

--- a/Part 1/python_solution/Exchange.py
+++ b/Part 1/python_solution/Exchange.py
@@ -1,0 +1,98 @@
+#! /usr/bin/env python
+
+class Order:
+    '''
+    Represent and order by splitting the input file appropriately
+    generation is maintained as a class static
+    '''
+    def __init__(self, str):
+        self.id, self.instrument, self.qty, self.price = str.strip().split(":")
+        self.qty = int(self.qty)
+        self.price = float(self.price)
+        self.generation = Order.next_generation()
+        if self.qty < 0:
+            self.qty = -self.qty
+            self.side = 'S'
+        else:
+            self.side = 'B'
+
+    generation = 0
+    @classmethod
+    def next_generation(cls):
+        cls.generation += 1
+        return cls.generation
+
+class Trade:
+    '''
+    No logic here, just a container that can be compared for equal
+    '''
+    def __init__(self, buyer, seller, instrument, qty, price):
+        self.buyer = buyer
+        self.seller = seller
+        self.instrument = instrument
+        self.qty = qty
+        self.price = price
+
+    def __str__(self):
+        return ':'.join((self.buyer, self.seller, self.instrument, 
+                str(self.qty), str(self.price)))
+
+class OrderBook:
+    def __init__(self, instrument):
+        self.instrument = instrument
+        # Top of the order book is LAST element
+        self.buys = []
+        self.sells = []
+    
+    def append(self, o):
+        if o.side == "B":
+            self.buys.append(o)
+            # highet price then lowest generation last 
+            self.buys.sort(key=lambda o: (o.price, -o.generation))
+        else:
+            self.sells.append(o)
+            # lowest price then lowest generation last
+            self.sells.sort(key=lambda o: (-o.price , -o.generation))
+
+    def match(self):
+        '''
+        The guts of the exchange matching logic
+        returns a list ot Trade objects
+        '''
+        ret = []
+
+        while self.buys and self.sells:
+            buy = self.buys[-1]
+            sell = self.sells[-1]
+            if buy.price < sell.price:
+                break
+            tprice = buy.price if buy.generation < sell.generation else sell.price
+            if buy.qty > sell.qty:
+                tqty = sell.qty
+                self.sells.pop()
+                buy.qty -= tqty
+            elif sell.qty > buy.qty:
+                tqty = buy.qty
+                self.buys.pop()
+                sell.qty -= tqty
+            else: # equal
+                tqty = buy.qty
+                self.buys.pop()
+                self.sells.pop()
+            ret.append(Trade(buy.id, sell.id, buy.instrument, tqty, tprice))
+            
+        return ret
+
+if __name__ == "__main__":
+    import sys
+    books = {}
+    for l in sys.stdin:
+        if len(l) < 2: break # empty last line due to \r\n
+        o = Order(l)
+        try:
+            b = books[o.instrument]
+        except KeyError:
+            b = books[o.instrument] = OrderBook(o.instrument)
+        b.append(o)
+        for t in b.match():
+            print(t)

--- a/Part 1/python_solution/README.md
+++ b/Part 1/python_solution/README.md
@@ -1,0 +1,17 @@
+# Python solution
+
+This version is a fairly straight-forward mapping of the C++ code to Python.  It will run under Python 2.7 or 3.6.  Output matches the C++ version for the 100k orders test.
+
+Interestingly, it's quite a bit faster under python3.6 than python2.7 on my Mac Air.
+
+Python 2.7:
+
+    real	6m41.565s
+    user	6m37.383s
+    sys	0m1.236s
+
+Python 3.6
+
+    real	5m2.788s
+    user	5m0.511s
+    sys	0m0.620s

--- a/Part 1/python_solution/test_order.py
+++ b/Part 1/python_solution/test_order.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env python
+
+import unittest
+import Exchange
+
+class TestOrder(unittest.TestCase):
+    def test_create(self):
+        o = Exchange.Order("A:AUDUSD:100:1.47\n")
+        self.assertEqual(o.qty, 100)
+        self.assertEqual(o.instrument, "AUDUSD")
+        self.assertEqual(o.id, "A")
+        self.assertEqual(o.price, 1.47)
+        self.assertEqual(o.side, "B")
+
+    def test_create_sell(self):
+        o = Exchange.Order("A:AUDUSD:-100:1.47\n")
+        self.assertEqual(o.qty, 100)
+        self.assertEqual(o.instrument, "AUDUSD")
+        self.assertEqual(o.id, "A")
+        self.assertEqual(o.price, 1.47)
+        self.assertEqual(o.side, "S")
+
+    def test_generation(self):
+        o = Exchange.Order("A:AUDUSD:-100:1.47\n")
+        o2 = Exchange.Order("A:AUDUSD:-100:1.47\n")
+        self.assertGreater(o2.generation, o.generation)
+        
+if __name__ == "__main__":
+    unittest.main()

--- a/Part 1/python_solution/test_orderbook.py
+++ b/Part 1/python_solution/test_orderbook.py
@@ -1,0 +1,117 @@
+#! /usr/bin/env python
+
+import unittest
+import Exchange
+
+class TestOrderBook(unittest.TestCase):
+    def test_create(self):
+        o = Exchange.OrderBook("AUDUSD")
+        self.assertEqual(o.instrument, "AUDUSD")
+        self.assertEqual(o.buys, [])
+        self.assertEqual(o.sells, [])
+    
+    def test_append(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A:AUDUSD:100:1.47\n"))
+        self.assertEqual(len(b.buys), 1)
+        self.assertEqual(len(b.sells), 0)
+        self.assertEqual(b.buys[0].qty, 100)
+
+    def test_append_sell(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A:AUDUSD:-100:1.47\n"))
+        self.assertEqual(len(b.buys), 0)
+        self.assertEqual(len(b.sells), 1)
+        self.assertEqual(b.sells[0].qty, 100)
+
+class TestSorting(unittest.TestCase):
+    def test_append_sort_buy_inorder(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A:AUDUSD:100:1.47\n"))
+        b.append(Exchange.Order("A:AUDUSD:200:1.47\n"))
+        self.assertEqual(len(b.buys), 2)
+        self.assertEqual(len(b.sells), 0)
+        # remember, last element is top of book
+        self.assertEqual(b.buys[0].qty, 200)
+        self.assertEqual(b.buys[1].qty, 100)
+       
+    def test_append_sort_sell_inorder(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A:AUDUSD:-100:1.47\n"))
+        b.append(Exchange.Order("A:AUDUSD:-200:1.47\n"))
+        self.assertEqual(len(b.sells), 2)
+        self.assertEqual(len(b.buys), 0)
+        # remember, last element is top of book
+        self.assertEqual(b.sells[0].qty, 200)
+        self.assertEqual(b.sells[1].qty, 100)
+       
+    def test_append_sort_buy_rev(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A:AUDUSD:200:1.48\n"))
+        b.append(Exchange.Order("A:AUDUSD:100:1.47\n"))
+        self.assertEqual(len(b.buys), 2)
+        self.assertEqual(len(b.sells), 0)
+        # for buys, last element has higest price
+        self.assertEqual(b.buys[0].qty, 100)
+        self.assertEqual(b.buys[1].qty, 200)
+       
+    def test_append_sort_sell_rev(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A:AUDUSD:-200:1.48\n"))
+        b.append(Exchange.Order("A:AUDUSD:-100:1.47\n"))
+        # for sells, last element has higest price
+        self.assertEqual(len(b.sells), 2)
+        self.assertEqual(len(b.buys), 0)
+        self.assertEqual(b.sells[0].qty, 200)
+        self.assertEqual(b.sells[1].qty, 100)
+       
+class TestMatch(unittest.TestCase):
+    def test_not_overlapped(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A:AUDUSD:200:1.46\n"))
+        b.append(Exchange.Order("A:AUDUSD:-100:1.47\n"))
+        self.assertEqual(b.match(), [])
+
+
+    def test_same_size(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A:AUDUSD:100:1.48\n"))
+        b.append(Exchange.Order("A:AUDUSD:-100:1.47\n"))
+        # Overlap, price is the first entry in the book
+        tlist = b.match()
+        self.assertEqual(len(tlist), 1)
+        self.assertEqual(str(tlist[0]), "A:A:AUDUSD:100:1.48")
+        # check that the books have been updated
+        self.assertEqual(len(b.sells), 0)
+        self.assertEqual(len(b.buys), 0)
+     
+    def test_buy_bigger(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A:AUDUSD:200:1.48\n"))
+        b.append(Exchange.Order("A:AUDUSD:-100:1.47\n"))
+        # Overlap, price is the first entry in the book
+        tlist = b.match()
+        self.assertEqual(len(tlist), 1)
+        self.assertEqual(str(tlist[0]), "A:A:AUDUSD:100:1.48")
+        # check that the books have been updated
+        self.assertEqual(len(b.sells), 0)
+        self.assertEqual(len(b.buys), 1)
+        # buy should have 100 shs left
+        self.assertEqual(b.buys[-1].qty, 100)
+
+    def test_sell_bigger(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A:AUDUSD:100:1.48\n"))
+        b.append(Exchange.Order("A:AUDUSD:-200:1.47\n"))
+        # Overlap, price is the first entry in the book
+        tlist = b.match()
+        self.assertEqual(len(tlist), 1)
+        self.assertEqual(str(tlist[0]), "A:A:AUDUSD:100:1.48")
+        # check that the books have been updated
+        self.assertEqual(len(b.sells), 1)
+        self.assertEqual(len(b.buys), 0)
+        # sell should have 100 shs left
+        self.assertEqual(b.sells[-1].qty, 100)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Part 1/python_solution/test_trade.py
+++ b/Part 1/python_solution/test_trade.py
@@ -1,0 +1,20 @@
+#! /usr/bin/env python
+
+import unittest
+import Exchange
+
+class TestTrade(unittest.TestCase):
+    def test_create(self):
+        t = Exchange.Trade('Buyer', 'Seller', 'BHP', 100, 2.34)
+        self.assertEqual(t.buyer, 'Buyer')
+        self.assertEqual(t.seller, 'Seller')
+        self.assertEqual(t.instrument, 'BHP')
+        self.assertEqual(t.qty,100)
+        self.assertEqual(t.price, 2.34)
+
+    def test_str(self):
+        t = Exchange.Trade('Buyer', 'Seller', 'BHP', 100, 2.34)
+        self.assertEqual(str(t), "Buyer:Seller:BHP:100:2.34")
+        
+if __name__ == "__main__":
+    unittest.main()

--- a/Part 2/python_solution/Exchange.py
+++ b/Part 2/python_solution/Exchange.py
@@ -1,0 +1,116 @@
+#! /usr/bin/env python3
+
+class Order:
+    '''
+    Represent an order, no logic just a container
+    '''
+    __slots__ = ['id', 'qty', 'price', 'side']
+    def __init__(self, id, qty, price):
+        self.id = id
+        self.qty = int(qty)
+        self.price = float(price)
+        if self.qty < 0:
+            self.qty = -self.qty
+            self.side = 'S'
+        else:
+            self.side = 'B'
+
+class Trade:
+    '''
+    No logic here, just a container that can be string-d
+    '''
+    __slots__ = ['buyer', 'seller', 'instrument', 'qty', 'price']
+    def __init__(self, buyer, seller, instrument, qty, price):
+        self.buyer = buyer
+        self.seller = seller
+        self.instrument = instrument
+        self.qty = qty
+        self.price = price
+
+    def __str__(self):
+        return ':'.join((self.buyer, self.seller, self.instrument, 
+                str(self.qty), str(self.price)))
+
+class OrderBook:
+    def __init__(self, instrument):
+        self.instrument = instrument
+        # Top of the order book is First element
+        self.buys = []
+        self.sells = []
+        self.last_order = None
+        self.best_bid = 0.0
+        self.best_offer = 1e10
+    
+    def append(self, o):
+        self.last_order = o
+        if o.side == "B":
+            self.buys.append(o)
+            if o.price > self.best_bid:
+                    self.best_bid = o.price
+            # Higest price first, rest assumes stable sort()
+            #self.buys.sort(reverse=True, key=lambda o: o.price)
+        else:
+            self.sells.append(o)
+            if o.price < self.best_offer:
+                self.best_offer = o.price
+            # lowest price first, rest assumes stable sort()
+            #self.sells.sort(key=lambda o: o.price)
+
+    def match(self):
+        '''
+        The guts of the exchange matching logic
+        returns a list ot Trade objects
+        '''
+        ret = []
+
+        if self.best_bid < self.best_offer:
+            return ret
+
+        self.sort_books()
+        while self.buys and self.sells and self.best_bid >= self.best_offer:
+            buy = self.buys[0]
+            sell = self.sells[0]
+            # if buy.price < sell.price:
+            #     break
+            tprice = buy.price if self.last_order.side == "S" else sell.price
+            if buy.qty > sell.qty:
+                tqty = sell.qty
+                self.sells.pop(0)
+                self.best_offer = self.sells[0].price if self.sells else 1e10
+                buy.qty -= tqty
+            elif sell.qty > buy.qty:
+                tqty = buy.qty
+                self.buys.pop(0)
+                self.best_bid = self.buys[0].price if self.buys else 0.0
+                sell.qty -= tqty
+            else: # equal
+                tqty = buy.qty
+                self.buys.pop(0)
+                self.sells.pop(0)
+                self.best_bid = self.buys[0].price if self.buys else 0.0
+                self.best_offer = self.sells[0].price if self.sells else 1e10
+            ret.append(Trade(buy.id, sell.id, self.instrument, tqty, tprice))
+            
+        return ret
+
+    def sort_books(self):
+        '''
+        Extract this into a separate function so we can use it in the unit tests
+        '''
+        self.buys.sort(reverse=True, key=lambda o: o.price)
+        self.sells.sort(key=lambda o: o.price)
+
+if __name__ == "__main__":
+    import sys
+    books = {}
+    for l in sys.stdin:
+        if len(l) < 2: break # empty last line
+        id, instrument, qty, price = l.strip().split(":")
+        o = Order(id, qty, price)
+        try:
+            b = books[instrument]
+        except KeyError:
+            b = books[instrument] = OrderBook(instrument)
+        b.append(o)
+        for t in b.match():
+            print(t)

--- a/Part 2/python_solution/README.md
+++ b/Part 2/python_solution/README.md
@@ -1,0 +1,77 @@
+# Python solution
+
+## Python Version
+
+First change is to run under python3, it's quite a bit faster under python3.6 than python2.7 on my Mac Air, by an astonishing 25%.  For the 100k orders test:
+
+Python 2.7:
+
+    real	6m41.565s
+    user	6m37.383s
+    sys	    0m1.236s
+
+Python 3.6
+
+    real	5m2.788s
+    user	5m0.511s
+    sys	    0m0.620s
+
+## Don't copy Instrument
+
+The `Order` type is carrying the Instrument, but doesn't need it, only use for this is in the OrderBook, which has it's own copy.  This does mean the split of the input line has to be hoisted to the main loop.
+
+Saving is a few seconds only:
+
+    real	4m58.007s
+    user	4m54.015s
+    sys 	0m0.623s
+
+## Use `__slots__`
+
+The python `__slots__` class variable replaces the usual dict in an object for instance variables with a fixed array.  This greatly reduces the flexibility of the users of the class, but can be much faster to look up attributes.  As the Trade and Order objects are heavily used and really only used as PODs, this is a price we can afford.  As an aside, instance variables defined in `__slots__` also clash with class variables, which is not true for normal objects.
+
+This is a good win, over 15%:
+
+    real	4m14.815s
+    user	4m10.738s
+    sys 	0m0.482s
+
+## Omit the generation
+
+Python sort routine is both stable and very well optimised for nearly-sorted data, so there is no need to rely on generation number.  The OrderBook object can keep the latest added order to know which price to use. As we are relying on the stable sort, we can also change the `match()` code to expect the top of the order book to be the start of the array, which means we can append new orders into the *end* of the array.  This is slightly cheaper and the more common operation, so small extra saving there.
+
+This is a massive win, saving more than 50%. This is much more than I expected.  Some of this improvement can be attributed to the use of plain floats rather than tuples as the key to `sort()` (~50 sec on this test).
+
+    real	1m56.511s
+    user	1m54.546s
+    sys     0m0.301s
+
+## Lazy sort
+
+Sorting is clearly the expensive bit of the problem.  The OrderBook object could keep track of best bid & offer manually, and only bother sorting the arrays when running the match() and the prices are known to overlap.
+
+Given how well the Python [Timsort](https://en.wikipedia.org/wiki/Timsort) implementation handles nearly-sorted data (close to linear time), this might not be the win for Python that it might be for other environments that use more naive and general sort.
+
+As it turns out, this is by far the biggest optimization of all.  Amazing 95% improvement:
+
+    real	0m6.895s
+    user	0m6.685s
+    sys     0m0.082s
+
+That's 1/60th the time of the original version.... 
+
+# Failed optimizations
+
+## Compare Orders directly
+Sorting the order book is clearly an expensive part of the process, given the benefit of omitting the generation and simplifying the sort.  Can we simplify the sort even more by making the Order objects diurectly comparible?
+
+Turns out no, this is about 40% more expensive.
+
+# Possible further optimizations
+
+## Use Tuples for Orders
+
+Changing the Order objects to use `__slots__` was a reasonable win.  Given there is no methods on these objects, could replace them with tuples which should have even faster element lookup.  
+
+This will also sort naturally without needing a key function which might save even more time; try with natural sorting based on tuple, or with a key function to extract the price from the tuple.
+

--- a/Part 2/python_solution/test_order.py
+++ b/Part 2/python_solution/test_order.py
@@ -1,0 +1,22 @@
+#! /usr/bin/env python
+
+import unittest
+import Exchange
+
+class TestOrder(unittest.TestCase):
+    def test_create(self):
+        o = Exchange.Order("A", "100", "1.47")
+        self.assertEqual(o.qty, 100)
+        self.assertEqual(o.id, "A")
+        self.assertEqual(o.price, 1.47)
+        self.assertEqual(o.side, "B")
+
+    def test_create_sell(self):
+        o = Exchange.Order("A", "-100", "1.47")
+        self.assertEqual(o.qty, 100)
+        self.assertEqual(o.id, "A")
+        self.assertEqual(o.price, 1.47)
+        self.assertEqual(o.side, "S")
+       
+if __name__ == "__main__":
+    unittest.main()

--- a/Part 2/python_solution/test_orderbook.py
+++ b/Part 2/python_solution/test_orderbook.py
@@ -1,0 +1,121 @@
+#! /usr/bin/env python
+
+import unittest
+import Exchange
+
+class TestOrderBook(unittest.TestCase):
+    def test_create(self):
+        o = Exchange.OrderBook("AUDUSD")
+        self.assertEqual(o.instrument, "AUDUSD")
+        self.assertEqual(o.buys, [])
+        self.assertEqual(o.sells, [])
+    
+    def test_append(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A", "100", "1.47"))
+        self.assertEqual(len(b.buys), 1)
+        self.assertEqual(len(b.sells), 0)
+        self.assertEqual(b.buys[0].qty, 100)
+
+    def test_append_sell(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A", "-100", "1.47"))
+        self.assertEqual(len(b.buys), 0)
+        self.assertEqual(len(b.sells), 1)
+        self.assertEqual(b.sells[0].qty, 100)
+
+class TestSorting(unittest.TestCase):
+    def test_append_sort_buy_inorder(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A", "100", "1.47"))
+        b.append(Exchange.Order("A", "200", "1.47"))
+        self.assertEqual(len(b.buys), 2)
+        self.assertEqual(len(b.sells), 0)
+        # remember, first element is top of book
+        b.sort_books()
+        self.assertEqual(b.buys[0].qty, 100)
+        self.assertEqual(b.buys[1].qty, 200)
+       
+    def test_append_sort_sell_inorder(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A", "-100", "1.47"))
+        b.append(Exchange.Order("A", "-200", "1.47"))
+        self.assertEqual(len(b.sells), 2)
+        self.assertEqual(len(b.buys), 0)
+        # remember, first element is top of book
+        b.sort_books()
+        self.assertEqual(b.sells[0].qty, 100)
+        self.assertEqual(b.sells[1].qty, 200)
+       
+    def test_append_sort_buy_rev(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A", "200", "1.48"))
+        b.append(Exchange.Order("A", "100", "1.47"))
+        self.assertEqual(len(b.buys), 2)
+        self.assertEqual(len(b.sells), 0)
+        # for buys, first element has highest price
+        b.sort_books()
+        self.assertEqual(b.buys[0].qty, 200)
+        self.assertEqual(b.buys[1].qty, 100)
+       
+    def test_append_sort_sell_rev(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A", "-200", "1.48"))
+        b.append(Exchange.Order("A", "-100", "1.47"))
+        self.assertEqual(len(b.sells), 2)
+        self.assertEqual(len(b.buys), 0)
+        # for sells, first element has lowest price
+        b.sort_books()
+        self.assertEqual(b.sells[0].qty, 100)
+        self.assertEqual(b.sells[1].qty, 200)
+       
+class TestMatch(unittest.TestCase):
+    def test_not_overlapped(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A", "200", "1.46"))
+        b.append(Exchange.Order("A", "-100", "1.47"))
+        self.assertEqual(b.match(), [])
+
+
+    def test_same_size(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A", "100", "1.48"))
+        b.append(Exchange.Order("A", "-100", "1.47"))
+        # Overlap, price is the first entry in the book
+        tlist = b.match()
+        self.assertEqual(len(tlist), 1)
+        self.assertEqual(str(tlist[0]), "A:A:AUDUSD:100:1.48")
+        # check that the books have been updated
+        self.assertEqual(len(b.sells), 0)
+        self.assertEqual(len(b.buys), 0)
+     
+    def test_buy_bigger(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A", "200", "1.48"))
+        b.append(Exchange.Order("A", "-100", "1.47"))
+        # Overlap, price is the first entry in the book
+        tlist = b.match()
+        self.assertEqual(len(tlist), 1)
+        self.assertEqual(str(tlist[0]), "A:A:AUDUSD:100:1.48")
+        # check that the books have been updated
+        self.assertEqual(len(b.sells), 0)
+        self.assertEqual(len(b.buys), 1)
+        # buy should have 100 shs left
+        self.assertEqual(b.buys[0].qty, 100)
+
+    def test_sell_bigger(self):
+        b = Exchange.OrderBook("AUDUSD")
+        b.append(Exchange.Order("A", "100", "1.48"))
+        b.append(Exchange.Order("A", "-200", "1.47"))
+        # Overlap, price is the first entry in the book
+        tlist = b.match()
+        self.assertEqual(len(tlist), 1)
+        self.assertEqual(str(tlist[0]), "A:A:AUDUSD:100:1.48")
+        # check that the books have been updated
+        self.assertEqual(len(b.sells), 1)
+        self.assertEqual(len(b.buys), 0)
+        # sell should have 100 shs left
+        self.assertEqual(b.sells[0].qty, 100)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Part 2/python_solution/test_trade.py
+++ b/Part 2/python_solution/test_trade.py
@@ -1,0 +1,20 @@
+#! /usr/bin/env python
+
+import unittest
+import Exchange
+
+class TestTrade(unittest.TestCase):
+    def test_create(self):
+        t = Exchange.Trade('Buyer', 'Seller', 'BHP', 100, 2.34)
+        self.assertEqual(t.buyer, 'Buyer')
+        self.assertEqual(t.seller, 'Seller')
+        self.assertEqual(t.instrument, 'BHP')
+        self.assertEqual(t.qty,100)
+        self.assertEqual(t.price, 2.34)
+
+    def test_str(self):
+        t = Exchange.Trade('Buyer', 'Seller', 'BHP', 100, 2.34)
+        self.assertEqual(str(t), "Buyer:Seller:BHP:100:2.34")
+        
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Python implementations for python2 or python3 (but python3 is faster)

Part 1 naive implementation is ~6:45
Part 2 optimized implementation is ~6.5 seconds, a 60x speedup.

Both give the same results as the C++ version for the 100k orders test.